### PR TITLE
Removing unmapped contigs

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python 3.12.2
       uses: actions/setup-python@v1
       with:
-        python-version: 3.12.2
+        python-version: "3.12.2"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,6 +10,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: "3.12.2"
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python 3.12.2
       uses: actions/setup-python@v1
       with:
-        python-version: "3.12.2"
+        python-version: "3.12"
         allow-prereleases: true
     - name: Install dependencies
       run: |

--- a/gene_annotation2bed.py
+++ b/gene_annotation2bed.py
@@ -848,6 +848,15 @@ def write_bed(annotation_df: pd.DataFrame,
     )
     # Merge overlapping entries
     collapsed_df = merge_overlapping(joint_bed_df)
+    # removing unknown contigs and raise in terminal
+    filtered_collapsed_df = collapsed_df[~collapsed_df["chromosome"].str.startswith('Unknown')]
+
+    # Print all unknown contigs
+    print("Unknown contigs in the BED file:")
+    unknown_contigs = collapsed_df[collapsed_df["chromosome"].str.startswith('Unknown')]
+    for contig in unknown_contigs["chromosome"].unique():
+        print(contig)
+    print(f"Total unknown contig rows: {len(unknown_contigs)}")
     # Write the collapsed data to an output file
     output_file_name_maf = (
         f"output_{args.genome_build}_{args.output_file_suffix}.maf"
@@ -855,10 +864,10 @@ def write_bed(annotation_df: pd.DataFrame,
     output_file_name_bed = (
         f"output_{args.genome_build}_{args.output_file_suffix}.bed"
     )
-    collapsed_df.to_csv(output_file_name_maf, sep="\t",
-                        header=True, index=False)
-    collapsed_df.to_csv(output_file_name_bed, sep="\t",
-                        header=False, index=False)
+    filtered_collapsed_df.to_csv(output_file_name_maf, sep="\t",
+                                 header=True, index=False)
+    filtered_collapsed_df.to_csv(output_file_name_bed, sep="\t",
+                                 header=False, index=False)
 
 
 def main():

--- a/gene_annotation2bed.py
+++ b/gene_annotation2bed.py
@@ -849,13 +849,16 @@ def write_bed(annotation_df: pd.DataFrame,
     # Merge overlapping entries
     collapsed_df = merge_overlapping(joint_bed_df)
     # removing unknown contigs and raise in terminal
+    print(collapsed_df.head())
+    print(collapsed_df.tail())
     filtered_collapsed_df = collapsed_df[~collapsed_df["chromosome"].str.startswith('Unknown')]
 
     # Print all unknown contigs
     print("Unknown contigs in the BED file:")
     unknown_contigs = collapsed_df[collapsed_df["chromosome"].str.startswith('Unknown')]
-    for contig in unknown_contigs["chromosome"].unique():
-        print(contig)
+    print(f"These rows will not be present in the final bed file due to unknown contigs \n")
+    for _, row in unknown_contigs.iterrows():
+        print(f"{row['chromosome']} - {row['gene']}")
     print(f"Total unknown contig rows: {len(unknown_contigs)}")
     # Write the collapsed data to an output file
     output_file_name_maf = (

--- a/scripts/igv_report.py
+++ b/scripts/igv_report.py
@@ -49,7 +49,7 @@ def create_igv_report(bed_file: str, maf_file: str,
         {
             "name": 'BED',
             "type": '',
-            "url": f'{bed_file}.gz',
+            "url": f'{bed_file}.sorted.gz',
             "indexURL": f'{bed_file}.gz.tbi'
         },
     ]


### PR DESCRIPTION
Fixes error creating IGV reports

Removed entries in BED with contigs which don't map to chromosome.
i.e. NT_ ow NW_ prefixed contigs see: [https://hgvs-nomenclature.org/stable/background/refseq/](https://hgvs-nomenclature.org/stable/background/refseq/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/gene_annotation2bed/11)
<!-- Reviewable:end -->
